### PR TITLE
Added GitHub pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following image and information was given to show the desired output from th
 
 ___
 ## URL
-* The URL of the deployed application: 
+* The URL of the deployed application: https://lulose.github.io/01-Challenge/
 * The URL of the GitHub Repository: https://github.com/lulose/01-Challenge
 
 ___


### PR DESCRIPTION
Added the GitHub pages URL to the README file.

The GitHub pages URL currently appears to be showing the README.md instead of the index.html, however this may be caused by latency.